### PR TITLE
Fix import side effect

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,1 +1,10 @@
-print("Hello, World!")
+"""Example application entry point."""
+
+
+def main() -> None:
+    """Run the application."""
+    print("Hello, World!")
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    main()


### PR DESCRIPTION
## Summary
- avoid running print on import by adding `main()` and `__main__` guard

## Testing
- `python3 -m py_compile main.py`
- `python3 main.py`
- `python3 - <<'PY'
import main
PY`

------
https://chatgpt.com/codex/tasks/task_e_684d267b1768832fa72d3d022acd4c4e